### PR TITLE
Warn if >16 rx queues are requested in ixgbe

### DIFF
--- a/main.c
+++ b/main.c
@@ -644,6 +644,8 @@ static int __iosub_main(int argc, char *const *argv)
 				printf("max queue rx %u tx %u\n", dev_info.max_rx_queues, dev_info.max_tx_queues);
 				assert(num_queue <= dev_info.max_rx_queues);
 				assert(num_queue <= dev_info.max_tx_queues);
+				if (!strncmp(dev_info.driver_name, "net_ixgbe", strlen("net_ixgbe")) && num_queue > 16)
+					printf("[WARNING] Up to 16 rx queues available for RSS in ixgbe (using %u)\n", num_queue);
 				printf("MTU: min %u max %u\n", dev_info.min_mtu, dev_info.max_mtu);
 				assert(nic_conf[portid].rxmode.max_lro_pkt_size < dev_info.max_mtu);
 


### PR DESCRIPTION
In ixgbe, only 16 rx queues can be used for RSS although the device has >16 queues.